### PR TITLE
fix order of mppx and mppy in Phillips parser

### DIFF
--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -868,7 +868,7 @@ class _PropertyParser:
                 float(element.strip('"')) * 1000
                 for element in pixel_spacing_attribute.split(" ")
             ]
-            mpp_x, mpp_y = pixel_spacings[0], pixel_spacings[1]
+            mpp_y, mpp_x = pixel_spacings[0], pixel_spacings[1]
             md[PROPERTY_NAME_MPP_X] = mpp_x
             md[PROPERTY_NAME_MPP_Y] = mpp_y
         return md


### PR DESCRIPTION
This pull request fixes a bug introduced in https://github.com/Bayer-Group/tiffslide/pull/80 , where the order of MPPX and MPPY are reversed.

According to the DICOM spec, the first value is row mpp and second is column mpp.

> Physical distance in the imaging target (patient, specimen, or phantom) between the centers of each pixel, specified by a numeric pair - adjacent row spacing (delimiter) adjacent column spacing in mm. See Section 10.7.1.3 for further explanation of the value order.

source: https://dicom.innolitics.com/ciods/vl-whole-slide-microscopy-image/vl-whole-slide-microscopy-image-multi-frame-functional-groups/52009230/00289110/00280030

Related to https://github.com/Bayer-Group/tiffslide/pull/80#pullrequestreview-1758167075

cc: @erikogabrielsson