### PR TITLE
Pin zarr<3.0 because of ImportError

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -21,7 +21,7 @@ dependencies:
   - imagecodecs
   - pillow
   - tifffile>=2021.6.14
-  - zarr
+  - zarr<3.0
 
   # development dependencies
   - pre-commit        # [ TIFFSLIDE_DEVEL ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "fsspec!=2022.11.0,!=2023.1.0",
   "pillow",
   "tifffile>=2021.6.14",
-  "zarr>=2.11.0",
+  "zarr>=2.11.0,<3.0",
   "typing_extensions>=4.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Tiffslide will have to be refactored a bit to support the latest version of zarr, 3.0. For now, we pin zarr<3.0.

Fixes https://github.com/Bayer-Group/tiffslide/issues/89