### PR TITLE
Solves Bayer-Group/tiffslide#91

### DIFF
--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -745,14 +745,13 @@ class _PropertyParser:
             md["tiff.XResolution"] = float(x_resolution)
             md["tiff.YResolution"] = float(y_resolution)
 
-            RESUNIT = tifffile.TIFF.RESUNIT
             scale = {
-                RESUNIT.INCH: 25400.0,
-                RESUNIT.CENTIMETER: 10000.0,
-                RESUNIT.MILLIMETER: 1000.0,
-                RESUNIT.MICROMETER: 1.0,
-                RESUNIT.NONE: None,
-            }.get(resolution_unit, None)
+                "INCH": 25400.0,
+                "CENTIMETER": 10000.0,
+                "MILLIMETER": 1000.0,
+                "MICROMETER": 1.0,
+                "NONE": None,
+            }.get(resolution_unit.name, None)
             if scale is not None:
                 try:
                     mpp_x = scale / x_resolution

--- a/tiffslide/tiffslide.py
+++ b/tiffslide/tiffslide.py
@@ -745,13 +745,14 @@ class _PropertyParser:
             md["tiff.XResolution"] = float(x_resolution)
             md["tiff.YResolution"] = float(y_resolution)
 
+            RESUNIT = tifffile.RESUNIT
             scale = {
-                "INCH": 25400.0,
-                "CENTIMETER": 10000.0,
-                "MILLIMETER": 1000.0,
-                "MICROMETER": 1.0,
-                "NONE": None,
-            }.get(resolution_unit.name, None)
+                RESUNIT.INCH: 25400.0,
+                RESUNIT.CENTIMETER: 10000.0,
+                RESUNIT.MILLIMETER: 1000.0,
+                RESUNIT.MICROMETER: 1.0,
+                RESUNIT.NONE: None,
+            }.get(resolution_unit, None)
             if scale is not None:
                 try:
                     mpp_x = scale / x_resolution


### PR DESCRIPTION
Using the names of the resolution units instead of the ENUM that is not available in the newest version of `tifffile==v2025.2.18`

Solves #91 