### PR TITLE
tiffslide: add upper bound to tifffile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "imagecodecs",
   "fsspec>=2023.3.0",
   "pillow>=9.1.0",
-  "tifffile>=2023.7.4",
+  "tifffile>=2023.7.4,<2025.5.21",
   "zarr>=2.16.0,<3.0",
   "typing_extensions>=4.0",
 ]


### PR DESCRIPTION
Limit upper tifffile version for now to keep zarr2 support.

Will require a refactor to work with `zarr3` and `tifffile>=2025.5.21`