### PR TITLE
fix: pin tifffile<2026.5.2 and zarr<3.2, prepare v3.0.1 (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ...
 
+## [3.0.1] - 2026-07-03
+### Fixed
+- `tiffslide`: pin `tifffile<2026.5.2` and `zarr<3.2` to avoid `GroupNotFoundError`
+  when reading slides; `tifffile>=2026.5.2` switched `ZarrTiffStore` to zarr v3
+  metadata (`zarr.json` / NGFF 0.5) which is incompatible with tiffslide 3.0.0 (#100)
+- `environment.devenv.yml`: update outdated `python`, `tifffile`, and `zarr` pins
+  to match `pyproject.toml`
+
 ## [3.0.0] - 2026-03-12
 ### Changed
 - `tiffslide`: migrate to zarr v3

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -13,15 +13,15 @@ channels:
   - conda-forge
 
 dependencies:
-  - python>=3.7
+  - python>=3.11
   - pip
 
   # deps
-  - fsspec
+  - fsspec>=2024.10.0
   - imagecodecs
-  - pillow
-  - tifffile>=2021.6.14
-  - zarr<3.0
+  - pillow>=9.1.0
+  - tifffile>=2025.5.21,<2026.5.2
+  - zarr>=3.0,<3.2
 
   # development dependencies
   - pre-commit        # [ TIFFSLIDE_DEVEL ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
   "imagecodecs",
   "fsspec>=2024.10.0",
   "pillow>=9.1.0",
-  "tifffile>=2025.5.21",
-  "zarr>=3.0,<4.0",
+  "tifffile>=2025.5.21,<2026.5.2",
+  "zarr>=3.0,<3.2",
   "typing_extensions>=4.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
tifffile 2026.5.2 switched ZarrTiffStore to zarr v3 metadata (zarr.json / NGFF 0.5), which is incompatible with tiffslide 3.0.0's zarr v2 code path and caused GroupNotFoundError when reading slides.

- pyproject: pin tifffile>=2025.5.21,<2026.5.2 and zarr>=3.0,<3.2
- environment.devenv.yml: update outdated python/tifffile/zarr pins to match
- CHANGELOG: add 3.0.1 section

Verified the full test suite passes (150 passed) with the resolved combination tifffile 2026.4.11 + zarr 3.1.6.